### PR TITLE
update to new way of calling flatatt (not deprecated)

### DIFF
--- a/ckeditor/__init__.py
+++ b/ckeditor/__init__.py
@@ -4,7 +4,7 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
 # Following PEP 440 Standards
-__version__ ='4.4.7+dive.ckeditor.5' # update this when deploying new version to production
+__version__ ='4.4.7+dive.ckeditor.6' # update this when deploying new version to production
 
 if 'ckeditor' in settings.INSTALLED_APPS:
     # Confirm CKEDITOR_UPLOAD_PATH setting has been specified.

--- a/ckeditor/widgets.py
+++ b/ckeditor/widgets.py
@@ -7,7 +7,7 @@ from django.utils.html import conditional_escape
 from django.utils.encoding import force_text
 from django.utils.translation import get_language
 from django.core.exceptions import ImproperlyConfigured
-from django.forms.util import flatatt
+from django.forms.utils import flatatt
 
 from django.utils.functional import Promise
 from django.utils.encoding import force_text

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def get_source_files():
 
 setup(
     name='django-ckeditor',
-    version='4.4.7+dive.ckeditor.5',
+    version='4.4.7+dive.ckeditor.6',
     description='Django admin CKEditor integration.',
     long_description=open('README.rst', 'r').read() + open('AUTHORS.rst', 'r').read() + open('CHANGELOG.rst', 'r').read(),
     author='Shaun Sephton & Piotr Malinski',


### PR DESCRIPTION
closes #23 

To test: 
Launch divesite with current version. Observe the warning:
```
/root/.virtualenvs/divesite/src/django-ckeditor/ckeditor/widgets.py:10: RemovedInDjango19Warning: The django.forms.util module has been renamed. Use django.forms.utils instead.
  from django.forms.util import flatatt
```

Change `reqs.txt` to require `fafeca78f2f2f850cc318d15418cbb778d159ed1`. `pip install -r reqs.txt`. Start divesite again and observe that you no longer see the warning.

Yay!