### PR TITLE
25 pullquote speaker optional (closes #25)

### DIFF
--- a/ckeditor/static/ckeditor/ckeditor/plugins/divepullquote/dialogs/divepullquote.js
+++ b/ckeditor/static/ckeditor/ckeditor/plugins/divepullquote/dialogs/divepullquote.js
@@ -39,11 +39,16 @@ CKEDITOR.dialog.add('divepullquote', function(editor){
 						},
 						commit: function( widget ) {
 							//get the actual img dom element, not some ckeditor psuedo element wrapped bullshit
-							var img = widget.editables.imgDiv.getFirst().getFirst().$,
-                                // Placeholder to set empty img src to before we hide it. We can't just remove
-                                // the img if the src is empty bc editors might want to add an img later and the
-                                // element still needs to be there.
-                                placeholder = 'https://d12v9rtnomnebu.cloudfront.net/dive_static/diveimages/corporate_site/teampage/square_profiles/placeholder-200.png';
+                            if (widget.editables.imgDiv.getFirst().getFirst() != null) {
+							    var img = widget.editables.imgDiv.getFirst().getFirst().$;
+                            } else {
+                                var img = widget.editables.imgDiv.getFirst().$;
+                            }
+                            
+                            // Placeholder to set empty img src to before we hide it. We can't just remove
+                            // the img if the src is empty bc editors might want to add an img later and the
+                            // element still needs to be there.
+                            var placeholder = 'https://d12v9rtnomnebu.cloudfront.net/dive_static/diveimages/corporate_site/teampage/square_profiles/placeholder-200.png';
 
 							//checks for an empty value or one space so we can delete image
 							if(this.getValue() === '' || this.getValue() === ' '){

--- a/ckeditor/static/ckeditor/ckeditor/plugins/divepullquote/dialogs/divepullquote.js
+++ b/ckeditor/static/ckeditor/ckeditor/plugins/divepullquote/dialogs/divepullquote.js
@@ -39,7 +39,7 @@ CKEDITOR.dialog.add('divepullquote', function(editor){
 						},
 						commit: function( widget ) {
 							//get the actual img dom element, not some ckeditor psuedo element wrapped bullshit
-							var img = widget.editables.imgDiv.getFirst().$,
+							var img = widget.editables.imgDiv.getFirst().getFirst().$,
                                 // Placeholder to set empty img src to before we hide it. We can't just remove
                                 // the img if the src is empty bc editors might want to add an img later and the
                                 // element still needs to be there.

--- a/ckeditor/static/ckeditor/ckeditor/plugins/divepullquote/dialogs/divepullquote.js
+++ b/ckeditor/static/ckeditor/ckeditor/plugins/divepullquote/dialogs/divepullquote.js
@@ -48,12 +48,16 @@ CKEDITOR.dialog.add('divepullquote', function(editor){
 							//checks for an empty value or one space so we can delete image
 							if(this.getValue() === '' || this.getValue() === ' '){
 								widget.setData('img_src', placeholder);
+                                img.setAttribute('src', widget.data.img_src);
+                                img.setAttribute('data-cke-saved-src', widget.data.img_src);
 								img.className = 'pq-headshot-img-hidden';
 							}
 							//if the user provides a url we set the widget's data.img_src property and make sure the image
 							//has a class that will show up on the page
 							else{
 								widget.setData('img_src', this.getValue());
+                                img.setAttribute('src', widget.data.img_src);
+                                img.setAttribute('data-cke-saved-src', widget.data.img_src);
 								img.className = 'pq-headshot-img';
 							}
 						}
@@ -74,7 +78,7 @@ CKEDITOR.dialog.add('divepullquote', function(editor){
 						type: 'text',
 						id: 'pq-speaker-title',
 						label: 'Speaker Title',
-						validate: CKEDITOR.dialog.validate.notEmpty( "Speaker title field cannot be empty." ),
+						// validate: CKEDITOR.dialog.validate.notEmpty( "Speaker title field cannot be empty." ),
 						setup: function( widget ) {
 							this.setValue(widget.data.speaker_title_value);
 						},

--- a/ckeditor/static/ckeditor/ckeditor/plugins/divepullquote/plugin.js
+++ b/ckeditor/static/ckeditor/ckeditor/plugins/divepullquote/plugin.js
@@ -94,7 +94,7 @@ CKEDITOR.plugins.add( 'divepullquote', {
 				//the div surrounding the img element is the editable element, so we
 				//need to get the reference to the img child of the surrounding div
 				if(imgDiv.getChildCount() > 0){
-					var img = imgDiv.getFirst().getFirst().$;
+					var img = imgDiv.getFirst().$;
 					//store the default src value of the img element in the widget data
 					this.setData('img_src',img.getAttribute('src'));
 				}
@@ -117,7 +117,7 @@ CKEDITOR.plugins.add( 'divepullquote', {
 				//the div surrounding the img element is the editable element, so we
 				//need to get the reference to the img child of the surrounding div
 				if(imgDiv.getChildCount() > 0) {
-					var img = imgDiv.getFirst().getFirst().$;
+					var img = imgDiv.getFirst().$;
 
 					//set both the src and 'data-cke-saved-src' of the img element...idk just what works with ckeditor
 					img.setAttribute('src', this.data.img_src);

--- a/ckeditor/static/ckeditor/ckeditor/plugins/divepullquote/plugin.js
+++ b/ckeditor/static/ckeditor/ckeditor/plugins/divepullquote/plugin.js
@@ -94,7 +94,7 @@ CKEDITOR.plugins.add( 'divepullquote', {
 				//the div surrounding the img element is the editable element, so we
 				//need to get the reference to the img child of the surrounding div
 				if(imgDiv.getChildCount() > 0){
-					var img = imgDiv.getFirst().$;
+					var img = imgDiv.getFirst().getFirst().$;
 					//store the default src value of the img element in the widget data
 					this.setData('img_src',img.getAttribute('src'));
 				}
@@ -117,7 +117,7 @@ CKEDITOR.plugins.add( 'divepullquote', {
 				//the div surrounding the img element is the editable element, so we
 				//need to get the reference to the img child of the surrounding div
 				if(imgDiv.getChildCount() > 0) {
-					var img = imgDiv.getFirst().$;
+					var img = imgDiv.getFirst().getFirst().$;
 
 					//set both the src and 'data-cke-saved-src' of the img element...idk just what works with ckeditor
 					img.setAttribute('src', this.data.img_src);


### PR DESCRIPTION
closes #25 

Makes speaker title optional, and also fixes img targeting on dialog commit. CKeditor was putting a weird extra `<p>` element around the `img` *after* the dialog is committed, but not on the widget `init`. Effing stupid.