### PR TITLE
28 speaker name optional (closes #28)

### DIFF
--- a/ckeditor/static/ckeditor/ckeditor/plugins/divepullquote/dialogs/divepullquote.js
+++ b/ckeditor/static/ckeditor/ckeditor/plugins/divepullquote/dialogs/divepullquote.js
@@ -71,7 +71,7 @@ CKEDITOR.dialog.add('divepullquote', function(editor){
 						type: 'text',
 						id: 'pq-speaker',
 						label: 'Speaker Name',
-						validate: CKEDITOR.dialog.validate.notEmpty( "Speaker name field cannot be empty." ),
+						// validate: CKEDITOR.dialog.validate.notEmpty( "Speaker name field cannot be empty." ),
 						setup: function( widget ) {
 							this.setValue(widget.data.speaker_value);
 						},


### PR DESCRIPTION
closes #28 

Makes speaker name optional on pullquote plugin.

Check out industrydive/divesite#3106 for testing. Remember to update that branch's `reqs.txt` with the new commit when you merge this in!