### PR TITLE
TECH-2967: Fix pullquote placeholder image URL

### DIFF
--- a/ckeditor/static/ckeditor/ckeditor/plugins/divepullquote/dialogs/divepullquote.js
+++ b/ckeditor/static/ckeditor/ckeditor/plugins/divepullquote/dialogs/divepullquote.js
@@ -48,7 +48,7 @@ CKEDITOR.dialog.add('divepullquote', function(editor){
                             // Placeholder to set empty img src to before we hide it. We can't just remove
                             // the img if the src is empty bc editors might want to add an img later and the
                             // element still needs to be there.
-                            var placeholder = 'https://d12v9rtnomnebu.cloudfront.net/dive_static/diveimages/corporate_site/teampage/square_profiles/placeholder-200.png';
+                            var placeholder = 'https://d12v9rtnomnebu.cloudfront.net/diveimages/corporate_site/teampage/square_profiles/placeholder-200.png';
 
 							//checks for an empty value or one space so we can delete image
 							if(this.getValue() === '' || this.getValue() === ' ' || this.getValue() == placeholder){

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def get_source_files():
 
 setup(
     name='django-ckeditor',
-    version='4.4.7+dive.ckeditor.7',
+    version='4.4.7+dive.ckeditor.8',
     description='Django admin CKEditor integration.',
     long_description=open('README.rst', 'r').read() + open('AUTHORS.rst', 'r').read() + open('CHANGELOG.rst', 'r').read(),
     author='Shaun Sephton & Piotr Malinski',


### PR DESCRIPTION
This was discovered via: https://industrydive.atlassian.net/browse/TECH-2967
It fixes the URL for the placeholder image in the pullquotes default value and bumps the version.
This issue was causing image download errors in the Facebook RSS Feed 
**Note this will not fix the issue for existing newsposts, only new ones going forward**

**To test:**

From the divesite CMS, create a new newspost and put a pullquote in it with no image URL. Switch to source view, and note that the default image has "dive_static" in the URL:
![screen shot 2017-11-06 at 4 04 44 pm](https://user-images.githubusercontent.com/22838218/32463970-67ad939e-c30c-11e7-8aac-54a80b502cf2.png)


pip install the latest commit from this branch in your divesite environment:
```
# pip install -e git+git://github.com/industrydive/django-ckeditor.git@34365faedc4a57278b664321763aa98127d38140#egg=django-ckeditor
Obtaining django-ckeditor from git+git://github.com/industrydive/django-ckeditor.git@34365faedc4a57278b664321763aa98127d38140#egg=django-ckeditor
  Skipping because already up-to-date.
Requirement already satisfied: Django in /root/.virtualenvs/divesite/lib/python2.7/site-packages (from django-ckeditor)
Requirement already satisfied: Pillow in /root/.virtualenvs/divesite/lib/python2.7/site-packages (from django-ckeditor)
Installing collected packages: django-ckeditor
  Found existing installation: django-ckeditor 4.4.7+dive.ckeditor.7
    Uninstalling django-ckeditor-4.4.7+dive.ckeditor.8:
      Successfully uninstalled django-ckeditor-4.4.7+dive.ckeditor.7
  Running setup.py develop for django-ckeditor
Successfully installed django-ckeditor
```

In the divesite CMS (you might need to use an incognito browser -- I could not get the cached JS to clear on my regular browser using a hard refresh), create a new newspost and put a pullquote in it with no image URL and switch to the view source mode. This time there should be no "dive_static" in the code:
![screen shot 2017-11-06 at 2 10 31 pm](https://user-images.githubusercontent.com/22838218/32464048-ae8abcec-c30c-11e7-811b-6b1e4cd2f1fe.png)

Once you have accepted this PR, merge the divesite requirements update: https://github.com/industrydive/divesite/pull/3676