### PR TITLE
Tech 3834 new autosave prompt

### DIFF
--- a/ckeditor/static/ckeditor/ckeditor/plugins/autosave/plugin.js
+++ b/ckeditor/static/ckeditor/ckeditor/plugins/autosave/plugin.js
@@ -249,10 +249,9 @@
                 // START NEW
                 $("#grp-context-navigation").append(
                     '<div class="admin_msg autosave-prompt-message" style="position:fixed;width:100%;margin-top:25px;border:none;padding-left:20px;"> \
-                        ALERT: You have an autosave version of this post: \
-                        <!-- ...from this time --> \
-                        Do you want to <a href="#" class="autosave-view">view the changes</a> or do you want to \
-                        <a href="#" class="autosave-discard"> discard the changes?</a> \
+                        ALERT: You have an autosaved version of this post <!-- ...from this time -->. \
+                        Do you want to <a href="#" class="autosave-discard"> discard the changes</a> or do you want to \
+                        <a href="#" class="autosave-view">view the changes?</a> \
                     </div>'
                 );
                 $("a.autosave-view").click(function(event){

--- a/ckeditor/static/ckeditor/ckeditor/plugins/autosave/plugin.js
+++ b/ckeditor/static/ckeditor/ckeditor/plugins/autosave/plugin.js
@@ -238,13 +238,36 @@
                 var confirmMessage = editorInstance.lang.autosave.loadSavedContent.replace("{0}",
                     moment(autoSavedContentDate).locale(editorInstance.config.language)
                     .format(editorInstance.lang.autosave.dateFormat));
-
-                if (confirm(confirmMessage)) {
-                    // Open DIFF Dialog
+                // START OLD
+                // if (confirm(confirmMessage)) {
+                //     // Open DIFF Dialog
+                //     editorInstance.openDialog('autosaveDialog');
+                // } else {
+                //     RemoveStorage(autoSaveKey, editorInstance);
+                // }
+                // END OLD
+                // START NEW
+                $("#grp-context-navigation").append(
+                    '<div class="admin_msg autosave-prompt-message" style="position:fixed;width:100%;margin-top:25px;border:none;padding-left:20px;"> \
+                        ALERT: You have an autosave version of this post: \
+                        <!-- ...from this time --> \
+                        Do you want to <a href="#" class="autosave-view">view the changes</a> or do you want to \
+                        <a href="#" class="autosave-discard"> discard the changes?</a> \
+                    </div>'
+                );
+                $("a.autosave-view").click(function(event){
+                    event.preventDefault();
                     editorInstance.openDialog('autosaveDialog');
-                } else {
+                    console.log("Accept!");
+                    $(".autosave-prompt-message").remove();
+                });
+                $("a.autosave-discard").click(function(event){
+                    event.preventDefault();
                     RemoveStorage(autoSaveKey, editorInstance);
-                }
+                    console.log("Discard!");
+                    $(".autosave-prompt-message").remove();
+                });
+                // END NEW
             }
         }
     }


### PR DESCRIPTION
Stop the autosave pop up from appearing automatically. Add a banner on the page instead that has 2 links: one shows the pop up, the other discards the local storage.