### PR TITLE
TECH-4547: Fix CKEditor deprecations

### DIFF
--- a/ckeditor/__init__.py
+++ b/ckeditor/__init__.py
@@ -4,7 +4,7 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
 # Following PEP 440 Standards
-__version__ ='4.4.7+dive.ckeditor.9' # update this when deploying new version to production
+__version__ ='4.4.7+dive.ckeditor.10' # update this when deploying new version to production
 
 if 'ckeditor' in settings.INSTALLED_APPS:
     # Confirm CKEDITOR_UPLOAD_PATH setting has been specified.

--- a/ckeditor/management/commands/generateckeditorthumbnails.py
+++ b/ckeditor/management/commands/generateckeditorthumbnails.py
@@ -1,19 +1,19 @@
 import os
 
 from django.conf import settings
-from django.core.management.base import NoArgsCommand
+from django.core.management.base import BaseCommand
 
 from ckeditor.views import get_image_files
 from ckeditor.utils import get_thumb_filename
 from ckeditor.image_processing import get_backend
 
 
-class Command(NoArgsCommand):
+class Command(BaseCommand):
     """
     Creates thumbnail files for the CKEditor file image browser.
     Useful if starting to use django-ckeditor with existing images.
     """
-    def handle_noargs(self, **options):
+    def handle(self, *args, **options):
         if getattr(settings, 'CKEDITOR_IMAGE_BACKEND', None):
             backend = get_backend()
             for image in get_image_files():

--- a/ckeditor/urls.py
+++ b/ckeditor/urls.py
@@ -1,11 +1,19 @@
-from django.conf.urls import patterns, url
+import django
+from django.conf.urls import url
 from django.contrib.admin.views.decorators import staff_member_required
 from django.views.decorators.cache import never_cache
 
 from ckeditor import views
 
-urlpatterns = patterns(
-    '',
-    url(r'^upload/', staff_member_required(views.upload), name='ckeditor_upload'),
-    url(r'^browse/', never_cache(staff_member_required(views.browse)), name='ckeditor_browse'),
-)
+if django.VERSION >= (1, 8):
+    urlpatterns = [
+        url(r'^upload/', staff_member_required(views.upload), name='ckeditor_upload'),
+        url(r'^browse/', never_cache(staff_member_required(views.browse)), name='ckeditor_browse'),
+    ]
+else:
+    from django.conf.urls import patterns
+    urlpatterns = patterns(
+        '',
+        url(r'^upload/', staff_member_required(views.upload), name='ckeditor_upload'),
+        url(r'^browse/', never_cache(staff_member_required(views.browse)), name='ckeditor_browse'),
+    )

--- a/ckeditor/views.py
+++ b/ckeditor/views.py
@@ -6,8 +6,7 @@ from django.core.files.storage import default_storage
 from django.views.decorators.csrf import csrf_exempt
 from django.views import generic
 from django.http import HttpResponse
-from django.shortcuts import render_to_response
-from django.template import RequestContext
+from django.shortcuts import render
 
 from ckeditor import image_processing
 from ckeditor import utils
@@ -138,7 +137,7 @@ def is_image(path):
 
 
 def browse(request):
-    context = RequestContext(request, {
+    context = {
         'files': get_files_browse_urls(request.user),
-    })
-    return render_to_response('browse.html', context)
+    }
+    return render(request, 'browse.html', context)

--- a/ckeditor/widgets.py
+++ b/ckeditor/widgets.py
@@ -101,7 +101,7 @@ class CKEditorWidget(forms.Textarea):
     def render(self, name, value, attrs={}):
         if value is None:
             value = ''
-        final_attrs = self.build_attrs(attrs, name=name)
+        final_attrs = self.build_attrs(self.attrs, attrs, name=name)
         self.config.setdefault('filebrowserUploadUrl', reverse('ckeditor_upload'))
         self.config.setdefault('filebrowserBrowseUrl', reverse('ckeditor_browse'))
         if not self.config.get('language'):
@@ -117,3 +117,13 @@ class CKEditorWidget(forms.Textarea):
             'config': json_encode(self.config),
             'external_plugin_resources' : json_encode(external_plugin_resources)
         }))
+
+    def build_attrs(self, base_attrs, extra_attrs=None, **kwargs):
+        """
+        Helper function for building an attribute dictionary.
+        This is combination of the same method from Django<=1.10 and Django1.11+
+        """
+        attrs = dict(base_attrs, **kwargs)
+        if extra_attrs:
+            attrs.update(extra_attrs)
+        return attrs

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def get_source_files():
 
 setup(
     name='django-ckeditor',
-    version='4.4.7+dive.ckeditor.8',
+    version='4.4.7+dive.ckeditor.10',
     description='Django admin CKEditor integration.',
     long_description=open('README.rst', 'r').read() + open('AUTHORS.rst', 'r').read() + open('CHANGELOG.rst', 'r').read(),
     author='Shaun Sephton & Piotr Malinski',


### PR DESCRIPTION
[TECH-4547: Fix CKEditor deprecations](https://industrydive.atlassian.net/browse/TECH-4547)
 
### In a nutshell
Resolve Django 1.8 - 1.11 deprecations in our custom CKEditor repo
 
### Non-technical Context
See above.
 
### Technical Context
Many of these changes were already taken care of upstream. I was able to use some of the upstream code when resolving these.
 
### Reproduction Steps
N/A
 
### Definition of Done
All deprecated features have been replaced with their up-to-date replacements.
 
### Manual Testing Instructions
- Run a command with `Wall` that uses those files/that chunk of code (you may have to runserver and interact with the site). output both stdout and stderr to a single file. example: run `python -Wall manage.py runserver 0.0.0.0:8000 --settings=utility_settings &> my_filename.txt`. Observe no deprecation warnings originating from django-ckeditor.
- View the admin for the following apps and observe no deprecation warnings from django-ckeditor.:
  - event
  - jobboard
  - library
  - news
  - newsletter
  - pressrelease
  - signup
  - spotlight
- View the user submission form for SMT and observe no deprecation warnings from django-ckeditor.
- View the opinion form and observe no deprecation warnings from django-ckeditor.
 
### QA Checklist
- [ ] Devise edge cases to test the bug fix or feature being merged
- [ ] Make sure the code is clean and understandable
    - [ ] Ask for inline comments on unclear sections
- [ ] Ensure code is not overly inefficient
- [ ] Ensure documentation is understandable and accurate, including:
    - [ ] Code comments and doc strings
    - [ ] Public docmentation/how-to guides
    - [ ] Technical documentation
 - [ ] Set deployment notes on Jira ticket