### PR TITLE
Tech 7818 inline image attribution

### DIFF
--- a/ckeditor/__init__.py
+++ b/ckeditor/__init__.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
 # Following PEP 440 Standards
-__version__ ='4.4.7+dive.ckeditor.10' # update this when deploying new version to production
+__version__ ='47132f8e9418ca913801499d4dc5558c4f25a9e6' # update this when deploying new version to production
 
 if 'ckeditor' in settings.INSTALLED_APPS:
     # Confirm CKEDITOR_UPLOAD_PATH setting has been specified.

--- a/ckeditor/__init__.py
+++ b/ckeditor/__init__.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
 # Following PEP 440 Standards
-__version__ ='47132f8e9418ca913801499d4dc5558c4f25a9e6' # update this when deploying new version to production
+__version__ ='4.4.7+dive.ckeditor.12' # update this when deploying new version to production
 
 if 'ckeditor' in settings.INSTALLED_APPS:
     # Confirm CKEDITOR_UPLOAD_PATH setting has been specified.

--- a/ckeditor/static/ckeditor/ckeditor/plugins/diveimage/dialogs/diveimage.js
+++ b/ckeditor/static/ckeditor/ckeditor/plugins/diveimage/dialogs/diveimage.js
@@ -965,8 +965,8 @@
 							parseJsonAttribution: function(json_obj) {
 								var new_credit = '';
 
-								if ( json_obj.inlineAttribution.length ) {
-									new_credit = json_obj.inlineAttribution;
+								if ( json_obj.Attribution.length ) {
+									new_credit = json_obj.Attribution;
 								}
 
 								return new_credit;

--- a/ckeditor/static/ckeditor/ckeditor/plugins/diveimage/dialogs/diveimage.js
+++ b/ckeditor/static/ckeditor/ckeditor/plugins/diveimage/dialogs/diveimage.js
@@ -86,7 +86,7 @@
 				var img_id = this.getContentElement('advanced', 'dive_id').getValue();
 
 				if ( parseInt(img_id) > 0 ) {
-					var fetch_url = 'http://localhost:8000/api/v1/diveimage/get_data/?camelcase=1&id=' + img_id;
+					var fetch_url = '/api/v1/diveimage/get_data/?camelcase=1&id=' + img_id;
 					json_text = CKEDITOR.ajax.load(fetch_url);
 					json_obj = JSON.parse(json_text);
 					json_elem.setValue(json_text);

--- a/ckeditor/static/ckeditor/ckeditor/plugins/diveimage/dialogs/diveimage.js
+++ b/ckeditor/static/ckeditor/ckeditor/plugins/diveimage/dialogs/diveimage.js
@@ -965,20 +965,8 @@
 							parseJsonAttribution: function(json_obj) {
 								var new_credit = '';
 
-								if ( json_obj.attribution.length ) {
-									new_credit = json_obj.attribution;
-								}
-
-								if ( json_obj.attributionUrl.length ) {
-									var start_link = '<a href="' + json_obj.attributionUrl + '">';
-									var link_text = new_credit.length ? new_credit : json_obj.attributionUrl
-									new_credit = start_link + link_text + '</a>';
-								}
-
-								// set this so that we will replace the current
-								// credit
-								if ( ! new_credit.length ) {
-									new_credit = ' ';
+								if ( json_obj.inlineAttribution.length ) {
+									new_credit = json_obj.inlineAttribution;
 								}
 
 								return new_credit;

--- a/ckeditor/static/ckeditor/ckeditor/plugins/diveimage/dialogs/diveimage.js
+++ b/ckeditor/static/ckeditor/ckeditor/plugins/diveimage/dialogs/diveimage.js
@@ -965,8 +965,8 @@
 							parseJsonAttribution: function(json_obj) {
 								var new_credit = '';
 
-								if ( json_obj.Attribution.length ) {
-									new_credit = json_obj.Attribution;
+								if ( json_obj.attribution.length ) {
+									new_credit = json_obj.attribution;
 								}
 
 								return new_credit;

--- a/ckeditor/static/ckeditor/ckeditor/plugins/diveimage/dialogs/diveimage.js
+++ b/ckeditor/static/ckeditor/ckeditor/plugins/diveimage/dialogs/diveimage.js
@@ -86,7 +86,7 @@
 				var img_id = this.getContentElement('advanced', 'dive_id').getValue();
 
 				if ( parseInt(img_id) > 0 ) {
-					var fetch_url = '/api/v1/diveimage/get_data/?camelcase=1&id=' + img_id;
+					var fetch_url = 'http://localhost:8000/api/v1/diveimage/get_data/?camelcase=1&id=' + img_id;
 					json_text = CKEDITOR.ajax.load(fetch_url);
 					json_obj = JSON.parse(json_text);
 					json_elem.setValue(json_text);

--- a/ckeditor/static/ckeditor/ckeditor/plugins/diveimage/dialogs/diveimage.js
+++ b/ckeditor/static/ckeditor/ckeditor/plugins/diveimage/dialogs/diveimage.js
@@ -965,6 +965,7 @@
 							parseJsonAttribution: function(json_obj) {
 								var new_credit = '';
 								console.log('CHANGING THE IMAGE ATTRIBUTION NOW!!');
+								console.log(json_obj);
 
 								if ( json_obj.inlineAttribution.length ) {
 									new_credit = json_obj.inlineAttribution;

--- a/ckeditor/static/ckeditor/ckeditor/plugins/diveimage/dialogs/diveimage.js
+++ b/ckeditor/static/ckeditor/ckeditor/plugins/diveimage/dialogs/diveimage.js
@@ -964,8 +964,6 @@
 							},
 							parseJsonAttribution: function(json_obj) {
 								var new_credit = '';
-								console.log('CHANGING THE IMAGE ATTRIBUTION NOW!!');
-								console.log(json_obj);
 
 								if ( json_obj.inlineAttribution.length ) {
 									new_credit = json_obj.inlineAttribution;

--- a/ckeditor/static/ckeditor/ckeditor/plugins/diveimage/dialogs/diveimage.js
+++ b/ckeditor/static/ckeditor/ckeditor/plugins/diveimage/dialogs/diveimage.js
@@ -964,6 +964,7 @@
 							},
 							parseJsonAttribution: function(json_obj) {
 								var new_credit = '';
+								console.log('CHANGING THE IMAGE ATTRIBUTION NOW!!');
 
 								if ( json_obj.inlineAttribution.length ) {
 									new_credit = json_obj.inlineAttribution;

--- a/ckeditor/static/ckeditor/ckeditor/plugins/imagemodelwidget/dialogs/imagemodelwidget.js
+++ b/ckeditor/static/ckeditor/ckeditor/plugins/imagemodelwidget/dialogs/imagemodelwidget.js
@@ -28,8 +28,12 @@ CKEDITOR.dialog.add( 'imagemodelwidget', function( editor ) {
 								var attribution_area = parent_dialog.getContentElement(tab, prefix+'attribution');
 								var new_attribution = '';
 
-								if ( json_obj.inlineAttribution.length ) {
-									new_attribution = json_obj.inlineAattribution;
+								if ( json_obj.attribution.length ) {
+									new_attribution = json_obj.attribution;
+								}
+
+								if ( json_obj.attributionUrl.length ) {
+									new_attribution = '<a href="' + json_obj.attributionUrl + '">' + new_attribution + '</a>';
 								}
 
 								attribution_area.setValue(new_attribution);

--- a/ckeditor/static/ckeditor/ckeditor/plugins/imagemodelwidget/dialogs/imagemodelwidget.js
+++ b/ckeditor/static/ckeditor/ckeditor/plugins/imagemodelwidget/dialogs/imagemodelwidget.js
@@ -28,12 +28,8 @@ CKEDITOR.dialog.add( 'imagemodelwidget', function( editor ) {
 								var attribution_area = parent_dialog.getContentElement(tab, prefix+'attribution');
 								var new_attribution = '';
 
-								if ( json_obj.attribution.length ) {
-									new_attribution = json_obj.attribution;
-								}
-
-								if ( json_obj.attributionUrl.length ) {
-									new_attribution = '<a href="' + json_obj.attributionUrl + '">' + new_attribution + '</a>';
+								if ( json_obj.inlineAttribution.length ) {
+									new_attribution = json_obj.inlineAattribution;
 								}
 
 								attribution_area.setValue(new_attribution);

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def get_source_files():
 
 setup(
     name='django-ckeditor',
-    version='47132f8e9418ca913801499d4dc5558c4f25a9e6',
+    version='4.4.7+dive.ckeditor.12',
     description='Django admin CKEditor integration.',
     long_description=open('README.rst', 'r').read() + open('AUTHORS.rst', 'r').read() + open('CHANGELOG.rst', 'r').read(),
     author='Shaun Sephton & Piotr Malinski',

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def get_source_files():
 
 setup(
     name='django-ckeditor',
-    version='4.4.7+dive.ckeditor.11',
+    version='47132f8e9418ca913801499d4dc5558c4f25a9e6',
     description='Django admin CKEditor integration.',
     long_description=open('README.rst', 'r').read() + open('AUTHORS.rst', 'r').read() + open('CHANGELOG.rst', 'r').read(),
     author='Shaun Sephton & Piotr Malinski',


### PR DESCRIPTION
The js that the front end image attribution stuff touches has to do with figurebox, and diveimage.js
Figurebox doesnt require any changes, so we just had to change a couple of things where we are handling the replacement of caption and image attribution in the CMS. 
NOTE:
This PR will require that a new release be created to go out with the corresponding PR in divesite